### PR TITLE
fix(LocalMusicService): performance and functionality improvements

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     </queries>
 
     <application
+        android:largeHeap="true"
         android:allowBackup="true"
         android:icon="@mipmap/app_icon"
         android:roundIcon="@mipmap/app_icon_round"

--- a/android/app/src/main/java/app/unimusic/LocalMusicPlugin.java
+++ b/android/app/src/main/java/app/unimusic/LocalMusicPlugin.java
@@ -3,10 +3,8 @@ package app.unimusic;
 import android.Manifest;
 import android.content.ContentUris;
 import android.database.Cursor;
-import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
-import android.util.Base64;
 
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -17,9 +15,6 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
-
-import java.io.DataInputStream;
-import java.io.InputStream;
 
 @CapacitorPlugin(
         name = "LocalMusic",
@@ -42,39 +37,6 @@ public class LocalMusicPlugin extends Plugin {
             return "externalStorage";
         }
     }
-
-    @PluginMethod()
-    public void readSong(PluginCall call) {
-        String path = call.getString("path");
-        if (path == null) {
-            call.reject("readSong failed: missing path parameter");
-            return;
-        }
-
-        Uri uri = Uri.parse(path);
-
-        try {
-            InputStream inputStream = getActivity().getContentResolver().openInputStream(uri);
-            if (inputStream == null) {
-                call.reject("getSong failed: inputStream is null");
-                return;
-            }
-
-            byte[] bytes = new byte[inputStream.available()];
-            DataInputStream dataInputStream = new DataInputStream(inputStream);
-            dataInputStream.readFully(bytes);
-
-            String base64Data = Base64.encodeToString(bytes, Base64.DEFAULT);
-
-            JSObject result = new JSObject();
-            result.put("data", base64Data);
-
-            call.resolve(result);
-        } catch (Exception exception) {
-            call.reject("readSong failed: " + exception.getMessage());
-        }
-    }
-
 
     @PluginMethod()
     public void getSongs(PluginCall call) {

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -22,6 +22,7 @@ const config: CapacitorConfig = {
 		"@capacitor/status-bar",
 	],
 	android: {
+		adjustMarginsForEdgeToEdge: "auto",
 		includePlugins: [
 			"@capacitor/app",
 			"@capacitor/filesystem",

--- a/src/plugins/LocalMusicPlugin.ts
+++ b/src/plugins/LocalMusicPlugin.ts
@@ -6,7 +6,6 @@ export interface LocalSongInfo {
 }
 
 export interface LocalMusicPlugin {
-	readSong(data: { path: string }): Promise<{ data: string }>;
 	getSongs(): Promise<{ songs: LocalSongInfo[] }>;
 }
 

--- a/src/services/Music/LocalMusicService.ts
+++ b/src/services/Music/LocalMusicService.ts
@@ -15,7 +15,6 @@ import {
 	SearchResultItem,
 } from "@/services/Music/MusicService";
 
-import { base64StringToBuffer } from "@/utils/buffer";
 import { generateHash, generateUUID } from "@/utils/crypto";
 import { getPlatform } from "@/utils/os";
 import { audioMimeTypeFromPath } from "@/utils/path";
@@ -113,17 +112,13 @@ async function getFileStream(path: string): Promise<ReadableStream<Uint8Array>> 
 			});
 			return stream;
 		}
-		// TODO: Stream data on Android?
 		case "android": {
-			const { data } = await LocalMusic.readSong({ path });
-			const buffer = base64StringToBuffer(data);
-			const stream = new ReadableStream({
-				start(controller): void {
-					controller.enqueue(buffer);
-					controller.close();
-				},
-			});
-			return stream;
+			const fileSrc = Capacitor.convertFileSrc(path);
+			const response = await fetch(fileSrc);
+			if (!response.body) {
+				throw new Error(`Failed retrieving file stream for ${path}: body is empty.`);
+			}
+			return response.body;
 		}
 		default: {
 			const { Filesystem, Directory } = await import("@capacitor/filesystem");
@@ -560,7 +555,8 @@ export class LocalMusicService extends MusicService<"local"> {
 	}
 
 	async handlePlay(): Promise<void> {
-		const { path } = this.song!.data;
+		const song = this.song!;
+		const path = song.data.path;
 
 		const stream = await getFileStream(path);
 		const buffer = await new Response(stream).arrayBuffer();

--- a/src/services/Music/LocalMusicService.ts
+++ b/src/services/Music/LocalMusicService.ts
@@ -139,11 +139,11 @@ async function getFileStream(path: string): Promise<ReadableStream<Uint8Array>> 
 
 async function parseLocalSong(path: string, id: string): Promise<LocalSong> {
 	const stream = await getFileStream(path);
-
-	const metadata = await parseWebStream(stream, {
-		path,
-		mimeType: audioMimeTypeFromPath(path),
-	});
+	const metadata = await parseWebStream(
+		stream,
+		{ path, mimeType: audioMimeTypeFromPath(path) },
+		{ duration: true, skipPostHeaders: true },
+	);
 
 	const { common, format } = metadata;
 

--- a/src/stores/local-images.ts
+++ b/src/stores/local-images.ts
@@ -42,8 +42,9 @@ export const useLocalImages = defineStore("LocalImages", () => {
 		[url: string, unregisterToken: WeakRef<Blob>, style?: LocalImageStyle]
 	>();
 
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	function log(...args: unknown[]): void {
-		console.debug("%cLocalImageStore:", "color: #40080; font-weight: bold;", ...args);
+		// console.debug("%cLocalImageStore:", "color: #40080; font-weight: bold;", ...args);
 	}
 
 	const registry = new FinalizationRegistry((id: string) => {


### PR DESCRIPTION
- Adds support for streaming the local data on Android.
- Enables LargeHeap on Android, fixing crashes caused by OOM on some phones
- Fixes an issue, where some songs `duration` would not get parsed
- Fixes an issue in Electron app, where it would completely fail, when app had no permissions to some directory